### PR TITLE
Make constructor const and update to 2018 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "try-mutex"
 version = "0.1.1"
+edition = "2018"
 description = "Fast non-blocking mutex"
 categories = ["concurrency"]
 authors = ["Mike Pedersen <mike@mikepedersen.dk>"]
@@ -13,8 +14,5 @@ name = "bench"
 harness = false
 
 [dev-dependencies]
-criterion = "0.2.3"
-
-[dev-dependencies.compiletest_rs]
-version = "0.3.11"
-features = ["stable"]
+criterion = "0.3.3"
+static_assertions = "1.1.0"

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -1,9 +1,8 @@
-extern crate try_mutex;
-#[macro_use] extern crate criterion;
+#![allow(clippy::mutex_atomic)]
 
+use criterion::{black_box, Criterion, criterion_group, criterion_main};
 use std::sync::Mutex;
 use try_mutex::TryMutex;
-use criterion::{Criterion, black_box};
 
 fn build_try() {
     for _ in 0..100000 {

--- a/tests/compile-fail/guard.rs
+++ b/tests/compile-fail/guard.rs
@@ -1,9 +1,0 @@
-extern crate try_mutex;
-
-fn send<T: Send>(t: T) { }
-
-fn main() {
-    let m = try_mutex::TryMutex::new(false);
-    send(m.try_lock().unwrap());
-    //~^ ERROR the trait bound `*mut bool: std::marker::Send` is not satisfied in `try_mutex::TryMutexGuard<'_, bool>`
-}


### PR DESCRIPTION
If the constructor is `const` then you can create a static mutex which is very useful.

I was also having trouble getting the `compiletest_rs` tests to work so I switched it out for a `static_assertion`, which is shorter, simpler but functionally equivalent.