### PR TITLE
Impl `Send` for `TryMutexGuard` when `T: Send`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -127,6 +127,7 @@ impl<T> RefUnwindSafe for TryMutex<T> {}
 unsafe impl<T: Send> Send for TryMutex<T> {}
 unsafe impl<T: Send> Sync for TryMutex<T> {}
 unsafe impl<'a, T: Sync> Sync for TryMutexGuard<'a, T> {}
+unsafe impl<'a, T: Send> Send for TryMutexGuard<'a, T> {}
 
 impl<T> From<T> for TryMutex<T> {
     fn from(t: T) -> Self {


### PR DESCRIPTION
The std-lib `Mutex` requires that the lock is released on the same thread it was acquired given interaction with the OS scheduler. Given that this implementation has no such requirement, the `MutexGuard` can be `Send` iff `T: Send`. `T` need-not be `Sync` as a `MutexGuard` represents an exclusive reference to the underlying item.